### PR TITLE
Improve download error handling

### DIFF
--- a/src/components/batch/FastDownloadActions.tsx
+++ b/src/components/batch/FastDownloadActions.tsx
@@ -87,7 +87,7 @@ const FastDownloadActions = ({
       console.error('Download failed:', error);
       toast({
         title: "Download Failed",
-        description: "Failed to download file. Please try again.",
+        description: error instanceof Error ? error.message : 'Failed to download file.',
         variant: "destructive",
       });
     }

--- a/src/hooks/useDownloadHandler.ts
+++ b/src/hooks/useDownloadHandler.ts
@@ -36,6 +36,11 @@ export const useDownloadHandler = (
         return;
       } catch (error) {
         console.error('Instant download failed, falling back to generation:', error);
+        toast({
+          title: 'Download Failed',
+          description: error instanceof Error ? error.message : 'Download failed',
+          variant: 'destructive'
+        });
       }
     }
 
@@ -95,14 +100,14 @@ export const useDownloadHandler = (
         }
       } catch (error) {
         console.error('File generation and download failed:', error);
-        
+
         // Fallback to standard download
         if (processingSummary) {
           await downloadFile(processingSummary, format);
         } else {
           toast({
             title: "Download Failed",
-            description: "Unable to download file. Please try again.",
+            description: error instanceof Error ? error.message : 'Unable to download file.',
             variant: "destructive",
           });
         }

--- a/src/lib/storage/preGeneratedFileService.ts
+++ b/src/lib/storage/preGeneratedFileService.ts
@@ -4,7 +4,19 @@ export class PreGeneratedFileService {
     try {
       const response = await fetch(url);
       if (!response.ok) {
-        throw new Error(`Failed to download file: ${response.statusText}`);
+        let message = '';
+        try {
+          message = (await response.text()).trim();
+        } catch {
+          // ignore body read errors
+        }
+        if (!message) {
+          message =
+            response.status === 401 || response.status === 403
+              ? 'Unauthorized download – check Supabase bucket permissions'
+              : `Failed to download file: ${response.statusText}`;
+        }
+        throw new Error(message);
       }
       
       const blob = await response.blob();


### PR DESCRIPTION
## Summary
- check the HTTP response when downloading pre-generated files
- read the response body and throw an informative error
- surface download errors in UI toast messages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6866a4f041188331b04315ded482f35b