### PR TITLE
Add tests for download handler

### DIFF
--- a/src/hooks/__tests__/useDownloadHandler.test.ts
+++ b/src/hooks/__tests__/useDownloadHandler.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+import { useDownloadHandler } from '../useDownloadHandler';
+
+// mocks
+const toastMock = vi.fn();
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: toastMock }) }));
+
+const downloadFileMock = vi.fn();
+vi.mock('../useEnhancedDownload', () => ({ useEnhancedDownload: () => ({ downloadFile: downloadFileMock }) }));
+
+const downloadFromStorageMock = vi.fn();
+vi.mock('@/lib/storage/preGeneratedFileService', () => ({ PreGeneratedFileService: { downloadFileFromStorage: downloadFromStorageMock } }));
+
+const processJobMock = vi.fn();
+vi.mock('@/lib/services/automaticFileGenerationService', () => ({ AutomaticFileGenerationService: { processCompletedJob: processJobMock } }));
+
+const convertJobMock = vi.fn(() => ({ id: '1' }));
+vi.mock('@/lib/utils/batchJobConverter', () => ({ convertToBatchJob: convertJobMock }));
+
+const singleMock = vi.fn();
+const eqMock = vi.fn(() => ({ single: singleMock }));
+const selectMock = vi.fn(() => ({ eq: eqMock }));
+const fromMock = vi.fn(() => ({ select: selectMock }));
+vi.mock('@/integrations/supabase/client', () => ({ supabase: { from: fromMock } }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useDownloadHandler', () => {
+  it('uses existing url', async () => {
+    singleMock.mockResolvedValue({});
+    const setFileStatus = vi.fn();
+    const { result } = renderHook(() => useDownloadHandler({ csvUrl: 'csv', excelUrl: 'excel' }, setFileStatus));
+
+    await act(async () => {
+      await result.current.handleDownload('csv');
+    });
+
+    expect(downloadFromStorageMock).toHaveBeenCalledWith('csv', expect.stringContaining('.csv'));
+    expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({ title: 'Download Complete' }));
+  });
+
+  it('generates files when no url', async () => {
+    singleMock
+      .mockResolvedValueOnce({ data: { id: '1' } })
+      .mockResolvedValueOnce({ data: { csv_file_url: 'newCsv', excel_file_url: 'newX' } });
+
+    const setFileStatus = vi.fn();
+    const { result } = renderHook(() => useDownloadHandler({}, setFileStatus, '1'));
+
+    await act(async () => {
+      await result.current.handleDownload('csv');
+    });
+
+    expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({ title: 'Preparing Download' }));
+    expect(processJobMock).toHaveBeenCalled();
+    expect(downloadFromStorageMock).toHaveBeenCalledWith('newCsv', expect.stringContaining('.csv'));
+    expect(setFileStatus).toHaveBeenCalled();
+  });
+
+  it('falls back on error', async () => {
+    singleMock.mockResolvedValueOnce({ error: 'fail' });
+    const setFileStatus = vi.fn();
+    const processingSummary = { results: [] } as any;
+    const { result } = renderHook(() => useDownloadHandler({}, setFileStatus, '1', processingSummary));
+
+    await act(async () => {
+      await result.current.handleDownload('csv');
+    });
+
+    expect(downloadFileMock).toHaveBeenCalledWith(processingSummary, 'csv');
+  });
+});

--- a/src/lib/storage/__tests__/preGeneratedFileService.test.ts
+++ b/src/lib/storage/__tests__/preGeneratedFileService.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PreGeneratedFileService } from '../preGeneratedFileService';
+
+describe('PreGeneratedFileService.downloadFileFromStorage', () => {
+  const originalCreateObjectURL = window.URL.createObjectURL;
+  const originalRevokeObjectURL = window.URL.revokeObjectURL;
+  const anchor = { click: vi.fn(), set href(v: string) {}, set download(v: string) {} } as any;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    window.URL.createObjectURL = vi.fn(() => 'blob:url');
+    window.URL.revokeObjectURL = vi.fn();
+    vi.spyOn(document, 'createElement').mockReturnValue(anchor);
+    vi.spyOn(document.body, 'appendChild').mockImplementation(() => {});
+    vi.spyOn(document.body, 'removeChild').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    window.URL.createObjectURL = originalCreateObjectURL;
+    window.URL.revokeObjectURL = originalRevokeObjectURL;
+  });
+
+  it('downloads file successfully', async () => {
+    const blob = new Blob(['data']);
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, blob: () => Promise.resolve(blob) } as any);
+
+    await PreGeneratedFileService.downloadFileFromStorage('http://test', 'file.csv');
+
+    expect(global.fetch).toHaveBeenCalledWith('http://test');
+    expect(anchor.click).toHaveBeenCalled();
+    expect(window.URL.revokeObjectURL).toHaveBeenCalled();
+  });
+
+  it('throws when download fails', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, statusText: 'Not Found' } as any);
+
+    await expect(PreGeneratedFileService.downloadFileFromStorage('bad', 'file.csv')).rejects.toThrow('Failed to download file');
+  });
+});


### PR DESCRIPTION
## Summary
- add PreGeneratedFileService tests for success & failure
- add unit tests for useDownloadHandler

## Testing
- `npx vitest run` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6866a4f3c2188331b538a16c1e0a3715