### PR TITLE
Add tests for row mapping and CSV generation

### DIFF
--- a/src/lib/rowMapping/__tests__/mapper.test.ts
+++ b/src/lib/rowMapping/__tests__/mapper.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { mapResultsToOriginalRows } from '../mapper';
+
+function createPayeeRowData() {
+  const originalFileData = [
+    { payee: 'Alice', amount: 10 },
+    { payee: 'Bob', amount: 20 },
+    { payee: 'Alice', amount: 30 }
+  ];
+
+  const rowMappings = [
+    {
+      originalRowIndex: 0,
+      payeeName: 'Alice',
+      normalizedPayeeName: 'alice',
+      uniquePayeeIndex: 0,
+      standardizationResult: { original: 'Alice', normalized: 'alice', cleaningSteps: [] }
+    },
+    {
+      originalRowIndex: 1,
+      payeeName: 'Bob',
+      normalizedPayeeName: 'bob',
+      uniquePayeeIndex: 1,
+      standardizationResult: { original: 'Bob', normalized: 'bob', cleaningSteps: [] }
+    },
+    {
+      originalRowIndex: 2,
+      payeeName: 'Alice',
+      normalizedPayeeName: 'alice',
+      uniquePayeeIndex: 0,
+      standardizationResult: { original: 'Alice', normalized: 'alice', cleaningSteps: [] }
+    }
+  ];
+
+  const uniquePayeeNames = ['Alice', 'Bob'];
+  const uniqueNormalizedNames = ['alice', 'bob'];
+
+  return {
+    uniquePayeeNames,
+    uniqueNormalizedNames,
+    rowMappings,
+    originalFileData,
+    standardizationStats: {
+      totalProcessed: 3,
+      changesDetected: 0,
+      averageStepsPerName: 0,
+      mostCommonSteps: []
+    }
+  };
+}
+
+function createClassifications() {
+  return [
+    {
+      id: '1',
+      payeeName: 'Alice',
+      result: { classification: 'Business', confidence: 90, reasoning: '', processingTier: 'AI-Powered' },
+      timestamp: new Date()
+    },
+    {
+      id: '2',
+      payeeName: 'Bob',
+      result: { classification: 'Individual', confidence: 80, reasoning: '', processingTier: 'AI-Powered' },
+      timestamp: new Date()
+    }
+  ];
+}
+
+describe('mapResultsToOriginalRows', () => {
+  it('returns mapped results matching original file length', () => {
+    const payeeRowData = createPayeeRowData();
+    const classifications = createClassifications();
+    const mapped = mapResultsToOriginalRows(classifications, payeeRowData as any);
+    expect(mapped).toHaveLength(payeeRowData.originalFileData.length);
+  });
+});

--- a/src/lib/services/__tests__/fileGenerationService.test.ts
+++ b/src/lib/services/__tests__/fileGenerationService.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { FileGenerationService } from '../fileGenerationService';
+
+function createData() {
+  const originalFileData = [
+    { payee: 'Alice', amount: 10 },
+    { payee: 'Bob', amount: 20 },
+    { payee: 'Alice', amount: 30 }
+  ];
+
+  const classifications = [
+    {
+      id: '1',
+      payeeName: 'Alice',
+      result: { classification: 'Business', confidence: 90, reasoning: '', processingTier: 'AI-Powered', sicCode: '', sicDescription: '' },
+      timestamp: new Date()
+    },
+    {
+      id: '2',
+      payeeName: 'Bob',
+      result: { classification: 'Individual', confidence: 80, reasoning: '', processingTier: 'AI-Powered', sicCode: '', sicDescription: '' },
+      timestamp: new Date()
+    }
+  ];
+
+  return { originalFileData, classifications };
+}
+
+describe('FileGenerationService.generateCSVContent', () => {
+  it('preserves original row order and appends classification columns', () => {
+    const { originalFileData, classifications } = createData();
+    const csv = (FileGenerationService as any).generateCSVContent(classifications, originalFileData);
+    const lines = csv.split('\n');
+
+    expect(lines[0]).toContain('AI_Classification');
+    expect(lines).toHaveLength(originalFileData.length + 1);
+
+    const row1 = lines[1].slice(1, -1).split('\",\"');
+    const row2 = lines[2].slice(1, -1).split('\",\"');
+    const row3 = lines[3].slice(1, -1).split('\",\"');
+
+    expect(row1[0]).toBe('Alice');
+    expect(row2[0]).toBe('Bob');
+    expect(row3[0]).toBe('Alice');
+
+    expect(row1[2]).toBe('Business');
+    expect(row2[2]).toBe('Individual');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test verifying `mapResultsToOriginalRows` preserves input length
- test `FileGenerationService.generateCSVContent` for order and appended columns

## Testing
- `npx vitest run` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6866a92e1ca48331861c8cdf502d5e4b