### PR TITLE
Implement batch job cancellation handler

### DIFF
--- a/src/components/batch/BatchJobActionsHandler.tsx
+++ b/src/components/batch/BatchJobActionsHandler.tsx
@@ -1,15 +1,28 @@
 import { useToast } from '@/hooks/use-toast';
+import { useBatchJobCancellation } from '@/hooks/useBatchJobCancellation';
+import { useBatchJobStore } from '@/stores/batchJobStore';
 
 export const useBatchJobActionsHandler = () => {
   const { toast } = useToast();
 
-  const handleCancel = (jobId: string) => {
-    // TODO: Implement cancel functionality
-    toast({
-      title: "Cancel Job",
-      description: `Cancel functionality for job ${jobId.slice(0, 8)}... not yet implemented`,
-      variant: "destructive"
-    });
+  const updateJob = useBatchJobStore(state => state.updateJob);
+  const { handleCancelJob } = useBatchJobCancellation(updateJob);
+
+  const handleCancel = async (jobId: string) => {
+    try {
+      await handleCancelJob(jobId);
+      toast({
+        title: "Job Cancelled",
+        description: `Successfully cancelled job ${jobId.slice(0, 8)}...`,
+      });
+    } catch (error) {
+      console.error('Failed to cancel job:', error);
+      toast({
+        title: "Cancel Failed",
+        description: error instanceof Error ? error.message : 'Failed to cancel job',
+        variant: "destructive"
+      });
+    }
   };
 
   const handleJobDelete = async (jobId: string, removeJob: (jobId: string) => void) => {

--- a/src/components/batch/__tests__/BatchJobActionsHandler.test.ts
+++ b/src/components/batch/__tests__/BatchJobActionsHandler.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+import { useBatchJobActionsHandler } from '../BatchJobActionsHandler';
+
+// mocks
+const toastMock = vi.fn();
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: toastMock }) }));
+
+const handleCancelJobMock = vi.fn();
+vi.mock('@/hooks/useBatchJobCancellation', () => ({
+  useBatchJobCancellation: () => ({ handleCancelJob: handleCancelJobMock })
+}));
+
+const updateJobMock = vi.fn();
+vi.mock('@/stores/batchJobStore', () => ({
+  useBatchJobStore: (selector: any) => selector({ updateJob: updateJobMock })
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useBatchJobActionsHandler.handleCancel', () => {
+  it('cancels job and shows success toast', async () => {
+    handleCancelJobMock.mockResolvedValue({});
+
+    const { result } = renderHook(() => useBatchJobActionsHandler());
+
+    await act(async () => {
+      await result.current.handleCancel('1');
+    });
+
+    expect(handleCancelJobMock).toHaveBeenCalledWith('1');
+    expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({ title: 'Job Cancelled' }));
+  });
+
+  it('shows error toast on failure', async () => {
+    handleCancelJobMock.mockRejectedValue(new Error('fail'));
+
+    const { result } = renderHook(() => useBatchJobActionsHandler());
+
+    await act(async () => {
+      await result.current.handleCancel('1');
+    });
+
+    expect(handleCancelJobMock).toHaveBeenCalledWith('1');
+    expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({ title: 'Cancel Failed' }));
+  });
+});


### PR DESCRIPTION
## Summary
- implement actual cancellation logic in `useBatchJobActionsHandler`
- add unit tests for the new handler functionality

## Testing
- `npm run lint`
- `npm test`
- `npx vitest run --silent`

------
https://chatgpt.com/codex/tasks/task_b_6866af89e6d48331acb4f168cba2b1ed