### PR TITLE
Add vitest support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ VITE_SUPABASE_KEY=<your-supabase-publishable-key>
 
 An example file is provided at `.env.example`.
 
+## Running tests
+
+After installing dependencies with `npm i`, execute the test suite using:
+
+```bash
+npm test
+```
+
+This runs [Vitest](https://vitest.dev/) with React Testing Library.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/aa593c27-4290-4aba-a8b2-135ff8cd3602) and click on Share -> Publish.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -86,6 +87,8 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^1.5.0",
+    "@testing-library/react": "^14.1.2"
   }
 }


### PR DESCRIPTION
## Summary
- add vitest and React Testing Library deps
- add `npm test` script
- document how to run tests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6866af8a58fc83318524014a122c045c