### PR TITLE
Enable strict TypeScript settings

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -15,10 +15,10 @@
     "jsx": "react-jsx",
 
     /* Linting */
-    "strict": false,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "noImplicitAny": false,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitAny": true,
     "noFallthroughCasesInSwitch": false,
 
     "baseUrl": ".",


### PR DESCRIPTION
## Summary
- enable strict TypeScript compiler checks by default

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6866ba2821d883318fb270cd1ed4667b