### PR TITLE
refactor: add batch job type interfaces

### DIFF
--- a/src/components/batch/BatchJobCard.tsx
+++ b/src/components/batch/BatchJobCard.tsx
@@ -12,6 +12,7 @@ import BatchJobStatusIndicator from './BatchJobStatusIndicator';
 import LargeJobStatusIndicator from './LargeJobStatusIndicator';
 import LargeJobManagementPanel from './LargeJobManagementPanel';
 import { BatchJobAutoRefreshIndicator } from './BatchJobAutoRefreshIndicator';
+import { PollingState, StalledJobActions } from '@/types/batch';
 
 interface BatchJobCardProps {
   job: BatchJob;
@@ -19,8 +20,8 @@ interface BatchJobCardProps {
   isRefreshing?: boolean;
   isPolling?: boolean;
   isAutoPolling?: boolean; // Separate auto-polling state
-  pollingState?: any;
-  stalledJobActions?: any;
+  pollingState?: PollingState;
+  stalledJobActions?: StalledJobActions;
   onRefresh: () => void;
   onForceRefresh?: () => void; // FORCE REFRESH: Debug capability
   onForceSync?: () => Promise<BatchJob>; // EMERGENCY FIX

--- a/src/components/batch/BatchJobContainer.tsx
+++ b/src/components/batch/BatchJobContainer.tsx
@@ -10,15 +10,16 @@ import { useToast } from '@/hooks/use-toast';
 import { PerformanceCircuitBreaker } from '@/components/performance/PerformanceCircuitBreaker';
 import { useMemoryManager } from '@/lib/performance/memoryManager';
 import { useJobRecovery } from '@/hooks/useJobRecovery';
+import { PollingState, StalledJobActions } from '@/types/batch';
 
 
 interface BatchJobContainerProps {
   jobs: BatchJob[];
   payeeRowDataMap: Record<string, PayeeRowData>;
   refreshingJobs: Set<string>;
-  pollingStates: Record<string, any>;
+  pollingStates: Record<string, PollingState | undefined>;
   autoPollingJobs: Set<string>; // Track auto-polling jobs
-  stalledJobActions?: Record<string, any>;
+  stalledJobActions?: Record<string, StalledJobActions | undefined>;
   largeJobOptimization?: any;
   onRefresh: (jobId: string, silent?: boolean) => Promise<void>;
   onForceRefresh?: (jobId: string) => Promise<void>; // FORCE REFRESH: Debug capability

--- a/src/components/batch/BatchJobList.tsx
+++ b/src/components/batch/BatchJobList.tsx
@@ -3,14 +3,15 @@ import React from 'react';
 import { BatchJob } from '@/lib/openai/trueBatchAPI';
 import { PayeeRowData } from '@/lib/rowMapping';
 import VirtualizedBatchJobList from './VirtualizedBatchJobList';
+import { PollingState, StalledJobActions } from '@/types/batch';
 
 interface BatchJobListProps {
   jobs: BatchJob[];
   payeeRowDataMap: Record<string, PayeeRowData>;
   refreshingJobs: Set<string>;
-  pollingStates: Record<string, { isPolling: boolean }>;
+  pollingStates: Record<string, PollingState | undefined>;
   autoPollingJobs: Set<string>; // Track auto-polling jobs
-  stalledJobActions?: Record<string, any>;
+  stalledJobActions?: Record<string, StalledJobActions | undefined>;
   onRefresh: (jobId: string) => Promise<void>;
   onForceRefresh?: (jobId: string) => Promise<void>; // FORCE REFRESH: Debug capability
   onForceSync?: (jobId: string) => Promise<BatchJob>; // EMERGENCY FIX

--- a/src/components/batch/OptimizedBatchJobList.tsx
+++ b/src/components/batch/OptimizedBatchJobList.tsx
@@ -2,14 +2,15 @@ import React, { useMemo, useState } from 'react';
 import { BatchJob } from '@/lib/openai/trueBatchAPI';
 import { PayeeRowData } from '@/lib/rowMapping';
 import BatchJobCard from './BatchJobCard';
+import { PollingState, StalledJobActions } from '@/types/batch';
 
 interface OptimizedBatchJobListProps {
   jobs: BatchJob[];
   payeeRowDataMap: Record<string, PayeeRowData>;
   refreshingJobs: Set<string>;
-  pollingStates: Record<string, any>;
+  pollingStates: Record<string, PollingState | undefined>;
   autoPollingJobs: Set<string>;
-  stalledJobActions: Record<string, any>;
+  stalledJobActions: Record<string, StalledJobActions | undefined>;
   onRefresh: (jobId: string, silent?: boolean) => Promise<void>;
   onForceRefresh?: (jobId: string) => Promise<void>;
   onForceSync?: (jobId: string) => Promise<BatchJob>;

--- a/src/components/batch/VirtualizedBatchJobList.tsx
+++ b/src/components/batch/VirtualizedBatchJobList.tsx
@@ -3,14 +3,15 @@ import { FixedSizeList as List } from 'react-window';
 import { BatchJob } from '@/lib/openai/trueBatchAPI';
 import { PayeeRowData } from '@/lib/rowMapping';
 import BatchJobCard from './BatchJobCard';
+import { PollingState, StalledJobActions } from '@/types/batch';
 
 interface VirtualizedBatchJobListProps {
   jobs: BatchJob[];
   payeeRowDataMap: Record<string, PayeeRowData>;
   refreshingJobs: Set<string>;
-  pollingStates: Record<string, any>;
+  pollingStates: Record<string, PollingState | undefined>;
   autoPollingJobs: Set<string>; // Track auto-polling jobs
-  stalledJobActions?: Record<string, any>;
+  stalledJobActions?: Record<string, StalledJobActions | undefined>;
   onRefresh: (jobId: string, silent?: boolean) => Promise<void>;
   onForceRefresh?: (jobId: string) => Promise<void>; // FORCE REFRESH: Debug capability
   onForceSync?: (jobId: string) => Promise<BatchJob>; // EMERGENCY FIX

--- a/src/hooks/useBatchJobManager.ts
+++ b/src/hooks/useBatchJobManager.ts
@@ -12,6 +12,7 @@ import { useUnifiedAutoRefresh } from '@/hooks/useUnifiedAutoRefresh';
 import { useNetworkStatus } from '@/hooks/useNetworkStatus';
 import { useStablePerformanceMonitor } from '@/hooks/useStablePerformanceMonitor';
 import { PhantomJobDetector } from '@/lib/utils/phantomJobDetector';
+import { PollingState, StalledJobActions } from '@/types/batch';
 
 export const useBatchJobManager = () => {
   const {
@@ -162,7 +163,7 @@ export const useBatchJobManager = () => {
         console.warn(`[BATCH JOB MANAGER] Error detecting stalled job ${job.id}:`, error);
       }
       return acc;
-    }, {} as Record<string, any>);
+    }, {} as Record<string, StalledJobActions>);
   }, [stableJobs, batchJobActions.getStalledJobActions, networkHealthy, performanceStable]);
 
   // Memoized return object with health status
@@ -170,7 +171,7 @@ export const useBatchJobManager = () => {
     jobs: stableJobs,
     payeeDataMap,
     refreshingJobs: new Set<string>(), // Simplified - use unified polling state
-    pollingStates: refreshStates,
+    pollingStates: refreshStates as Record<string, PollingState>,
     autoPollingJobs: new Set(Object.keys(refreshStates).filter(jobId => refreshStates[jobId]?.isPolling)),
     stalledJobActions,
     handleRefreshJob,

--- a/src/types/batch.ts
+++ b/src/types/batch.ts
@@ -1,0 +1,16 @@
+export interface PollingState {
+  isPolling: boolean;
+  lastPoll: number;
+  pollCount: number;
+  consecutiveErrors: number;
+  lastStatus?: string;
+  lastProgress?: number;
+}
+
+export interface StalledJobActions {
+  isStalled: boolean;
+  suggestions?: string[];
+  canCancel: boolean;
+  payeeCount?: number;
+}
+


### PR DESCRIPTION
## Summary
- add shared `PollingState` and `StalledJobActions` interfaces
- type `BatchJobCard` props with the new interfaces
- update batch job list/container components to pass typed data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, etc.)*


------
https://chatgpt.com/codex/tasks/task_b_68a7823cd2c483319fe592da74337d05